### PR TITLE
Fix crash in isDebianSuitableForStaticLinking if version is non-numeric.

### DIFF
--- a/nuitka/utils/StaticLibraries.py
+++ b/nuitka/utils/StaticLibraries.py
@@ -81,7 +81,11 @@ def isDebianSuitableForStaticLinking():
         if dist_version is None:
             return True
 
-        dist_version = tuple(int(x) for x in dist_version.split("."))
+        try:
+            dist_version = tuple(int(x) for x in dist_version.split("."))
+        except ValueError:
+            # dist_version contains a non-numeric string such as "sid".
+            return True
 
         return dist_version >= (10,)
     else:


### PR DESCRIPTION
On Debian sid, dist_version == "sid" so int(x) raises a ValueError.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
